### PR TITLE
Calyptos issue #77 & #75: fix for not requiring default zookeeper port and server iteration

### DIFF
--- a/templates/default/zoo.cfg.erb
+++ b/templates/default/zoo.cfg.erb
@@ -25,6 +25,6 @@ clientPort=2181
 #autopurge.purgeInterval=1
 <% server_count = 1 %>
 <% for @item in node['midokura']['zookeepers'] -%>
-server.<%= server_count %>=<%= @item[0..-6] %>:2888:3888
+server.<%= server_count %>=<%= @item.split(":")[0] %>:2888:3888
 <% server_count + 1 %>
 <% end -%>

--- a/templates/default/zoo.cfg.erb
+++ b/templates/default/zoo.cfg.erb
@@ -23,8 +23,7 @@ clientPort=2181
 # Purge task interval in hours
 # Set to "0" to disable auto purge feature
 #autopurge.purgeInterval=1
-<% server_count = 1 %>
-<% for @item in node['midokura']['zookeepers'] -%>
-server.<%= server_count %>=<%= @item.split(":")[0] %>:2888:3888
-<% server_count + 1 %>
+
+<% node['midokura']['zookeepers'].each_with_index do |item,index| -%>
+server.<%= index %>=<%= @item.split(":")[0] %>:2888:3888
 <% end -%>


### PR DESCRIPTION
Fixes Calyptos Issue #77, backwards compatible with specifying optional port 2181
Now defaults to 2181 which isn't specified in the server definition
