### PR TITLE
possible resolution of .split error

### DIFF
--- a/templates/default/zoo.cfg.erb
+++ b/templates/default/zoo.cfg.erb
@@ -25,5 +25,5 @@ clientPort=2181
 #autopurge.purgeInterval=1
 
 <% node['midokura']['zookeepers'].each_with_index do |item,index| -%>
-server.<%= index %>=<%= @item.split(":")[0] %>:2888:3888
+server.<%= index %>=<%= item.split(":")[0] %>:2888:3888
 <% end -%>


### PR DESCRIPTION
Caused by @item instead of item, @ prefix only applies to scope which isn't defined thus nil:NilClass
