### PR TITLE
Only install midolman init from template on el6

### DIFF
--- a/recipes/midolman.rb
+++ b/recipes/midolman.rb
@@ -46,10 +46,14 @@ else
   end
 end
 
-# HACK: the midolman daemon does not support chkconfig nor does it properly report status
-template "/etc/init.d/midolman" do
-  source "midolman.init.erb"
-  mode "0655"
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+
+  # HACK: the midolman daemon does not support chkconfig nor does it properly report status
+  # because the el6 packaged init script is broken, continue to use our template for el6, but not for el7
+  template "/etc/init.d/midolman" do
+    source "midolman.init.erb"
+    mode "0655"
+  end
 end
 
 service 'midolman' do

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -85,10 +85,12 @@ if node['midokura']['uninstall']['destroy'] == true
     action :delete
   end
 
-  # HACK: the midolman daemon does not support chkconfig remove init we added
-  # TODO: mbacchi correct this, use systemd init on el7, fix handling on el6
-  file "/etc/init.d/midolman" do
-    action :delete
+  if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+    # HACK: the midolman daemon does not support chkconfig remove init we added
+
+    file "/etc/init.d/midolman" do
+      action :delete
+    end
   end
 
   file "/etc/tomcat/Catalina/localhost/midonet-api.xml" do


### PR DESCRIPTION
The init script in the el6 rpm is broken, use
our init script template for el6, but not for el7.
