### PR TITLE
Issue #32 move mn-conf to calyptos bootstrap phase

### DIFF
--- a/recipes/create-first-resources.rb
+++ b/recipes/create-first-resources.rb
@@ -17,21 +17,6 @@ execute 'Restart Tomcat and Midolman' do
   not_if "#{midonet_command_prefix} -e help || sleep 20 && #{midonet_command_prefix} -e help"
 end
 
-
-### Sets Cassandra server config in Zookeeper
-#### This overwrites the existing entries with whatever is in the cassandras attr
-cassandra_host_list = node['midokura']['cassandras'].join(',')
-Chef::Log.info("Setting Cassandra Servers: #{cassandra_host_list}")
-bash "Configure Cassandra Servers" do
-   code <<-EOH
-   echo "Setting Cassandra Servers: #{cassandra_host_list}"
-   echo 'cassandra.servers : "#{cassandra_host_list}"' | mn-conf set -t default
-   EOH
-   retries 6
-   retry_delay 10
-   flags '-xe'
-end
-
 execute 'Create TunnelZone' do
   command "#{midonet_command_prefix} -e add tunnel-zone name #{tunnel_zone_name} type gre"
   retries 20

--- a/recipes/nuke.rb
+++ b/recipes/nuke.rb
@@ -26,8 +26,19 @@ service 'zookeeper' do
 end
 
 ### Stop Cassandra service
-service "cassandra" do
-  action [ :stop ]
+if Chef::VersionConstraint.new("~> 6.0").include?(node['platform_version'])
+  service "cassandra" do
+    action [ :stop ]
+    only_if "ls /etc/rc.d/init.d/cassandra"
+  end
+end
+if Chef::VersionConstraint.new("~> 7.0").include?(node['platform_version'])
+  # stop cassandra service on el7 with service command, the current rpm (2.0.17-1)
+  # doesn't have a proper systemd unit file and therefore 'systemctl' fails
+  execute "Stop cassandra service with system V init" do
+    command "service cassandra stop"
+    only_if "ls /etc/rc.d/init.d/cassandra"
+  end
 end
 
 ### Stop Midolman service


### PR DESCRIPTION
Midolman needs to configure cassandra earlier than it had
been run previously (in create-first-resources.) Additional
calyptos changes will be coming in parallel with this to
reorder other steps so that midolman can connect to cassandra
reliably.
